### PR TITLE
Implement computer opponent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ If you like what you see, please ⭐ the repo.
 ## ✨ Features
 
 - 🧑‍🤝‍🧑 Ability to play Local Multiplayer (1v1)
+- 🎮 Play Against The Computer
 - 🕹️ Supported By The Keyboard as well as the Joystick
 - 🎨 Ability To Select From Multiple Different Themes (eq:- classic, football, matrix)
 - 🔉 Built In Sound Effects
 
 ### 🔜 Upcoming Features
-- 🎮 Play Against The Computer
-- 🌍 Play Realtime Online Multiplayer Against a Friend
+ - 🌍 Play Realtime Online Multiplayer Against a Friend
 
 ## 💻 Installation links
 

--- a/lib/components/pong_game.dart
+++ b/lib/components/pong_game.dart
@@ -20,6 +20,7 @@ class PongGame extends FlameGame
     required this.isMobile,
     required this.isSfxEnabled,
     required this.gameTheme,
+    this.vsComputer = false,
   }) : super(children: [ScreenHitbox()]);
 
   final bool isMobile;
@@ -27,6 +28,7 @@ class PongGame extends FlameGame
   late final double height;
   final bool isSfxEnabled;
   final GameTheme gameTheme;
+  final bool vsComputer;
   int leftPlayerScore = 0;
   int rightPlayerScore = 0;
   late final Vector2 paddleSize;
@@ -148,7 +150,7 @@ class PongGame extends FlameGame
       findByKey<Paddle>(
         ComponentKey.named('LeftPaddle'),
       )?.moveBy(event.localDelta.y * 2);
-    } else {
+    } else if (!vsComputer) {
       //To Move the Right Paddle By Drag
       findByKey<Paddle>(
         ComponentKey.named('RightPaddle'),
@@ -163,9 +165,10 @@ class PongGame extends FlameGame
   ) {
     super.onKeyEvent(event, keysPressed);
     //To Move the Right Paddle
-    if (keysPressed.contains(LogicalKeyboardKey.arrowUp)) {
+    if (!vsComputer && keysPressed.contains(LogicalKeyboardKey.arrowUp)) {
       findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.moveBy(-paddleStep);
-    } else if (keysPressed.contains(LogicalKeyboardKey.arrowDown)) {
+    } else if (!vsComputer &&
+        keysPressed.contains(LogicalKeyboardKey.arrowDown)) {
       findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.moveBy(paddleStep);
     }
     //To Move the Left Paddle
@@ -180,6 +183,22 @@ class PongGame extends FlameGame
       startGame();
     }
     return KeyEventResult.handled;
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (vsComputer && gameState == GameState.playing) {
+      final aiPaddle = findByKey<Paddle>(ComponentKey.named('RightPaddle'));
+      final balls = world.children.query<Ball>();
+      if (aiPaddle != null && balls.isNotEmpty) {
+        final ball = balls.first;
+        aiPaddle.position.y = (ball.position.y - aiPaddle.size.y / 2).clamp(
+          0,
+          height - aiPaddle.size.y,
+        );
+      }
+    }
   }
 
   void playPing() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,6 +55,7 @@ class EasyPongApp extends StatelessWidget {
       routes: {
         "/": (context) => const HomeScreen(),
         "/local_multiplayer": (context) => const GameApp(),
+        "/vs_computer": (context) => const GameApp(vsComputer: true),
         "/settings": (context) => const SettingsScreen(),
       },
     );

--- a/lib/overlays/welcome_overlay.dart
+++ b/lib/overlays/welcome_overlay.dart
@@ -4,7 +4,12 @@ import 'package:flutter/material.dart';
 
 class WelcomeOverlay extends StatelessWidget {
   final GameTheme gameTheme;
-  const WelcomeOverlay({super.key, required this.gameTheme});
+  final bool isVsComputer;
+  const WelcomeOverlay({
+    super.key,
+    required this.gameTheme,
+    this.isVsComputer = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -46,7 +51,9 @@ class WelcomeOverlay extends StatelessWidget {
           Expanded(
             child: Center(
               child: Text(
-                "Up Arrow to Move Up\nDown Arrow to Move Down",
+                isVsComputer
+                    ? "Computer Opponent"
+                    : "Up Arrow to Move Up\nDown Arrow to Move Down",
                 style: TextStyle(color: gameTheme.leftHudTextColor),
               ),
             ),

--- a/lib/overlays/winner_overlay.dart
+++ b/lib/overlays/winner_overlay.dart
@@ -7,12 +7,14 @@ class WinnerOverlay extends StatelessWidget {
   final GameTheme gameTheme;
   final int leftPlayerScore;
   final int rightPlayerScore;
+  final bool isVsComputer;
   final VoidCallback gameReplayPressed;
   const WinnerOverlay({
     super.key,
     required this.gameTheme,
     required this.leftPlayerScore,
     required this.rightPlayerScore,
+    this.isVsComputer = false,
     required this.gameReplayPressed,
   });
 
@@ -30,7 +32,9 @@ class WinnerOverlay extends StatelessWidget {
                 Text(
                   "$leftPlayerScore",
                   style: TextStyle(
-                      color: gameTheme.leftHudTextColor, fontSize: 32),
+                    color: gameTheme.leftHudTextColor,
+                    fontSize: 32,
+                  ),
                 ),
                 const SizedBox(height: 10),
                 Text(
@@ -38,7 +42,9 @@ class WinnerOverlay extends StatelessWidget {
                       ? "You Win"
                       : "You Lose",
                   style: TextStyle(
-                      color: gameTheme.leftHudTextColor, fontSize: 32),
+                    color: gameTheme.leftHudTextColor,
+                    fontSize: 32,
+                  ),
                 ),
               ],
             ),
@@ -68,13 +74,23 @@ class WinnerOverlay extends StatelessWidget {
                 Text(
                   "$rightPlayerScore",
                   style: TextStyle(
-                      color: gameTheme.rightHudTextColor, fontSize: 32),
+                    color: gameTheme.rightHudTextColor,
+                    fontSize: 32,
+                  ),
                 ),
                 const SizedBox(height: 10),
                 Text(
-                  (rightPlayerScore > leftPlayerScore) ? "You Win" : "You Lose",
+                  isVsComputer
+                      ? (rightPlayerScore > leftPlayerScore
+                          ? "Computer Wins"
+                          : "Computer Loses")
+                      : (rightPlayerScore > leftPlayerScore
+                          ? "You Win"
+                          : "You Lose"),
                   style: TextStyle(
-                      color: gameTheme.rightHudTextColor, fontSize: 32),
+                    color: gameTheme.rightHudTextColor,
+                    fontSize: 32,
+                  ),
                 ),
               ],
             ),

--- a/lib/overlays/winner_overlay.dart
+++ b/lib/overlays/winner_overlay.dart
@@ -26,73 +26,81 @@ class WinnerOverlay extends StatelessWidget {
         children: AnimateList(
           effects: [FadeEffect(duration: 300.ms)],
           children: [
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  "$leftPlayerScore",
-                  style: TextStyle(
-                    color: gameTheme.leftHudTextColor,
-                    fontSize: 32,
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    "$leftPlayerScore",
+                    style: TextStyle(
+                      color: gameTheme.leftHudTextColor,
+                      fontSize: 32,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  (leftPlayerScore >= rightPlayerScore)
-                      ? "You Win"
-                      : "You Lose",
-                  style: TextStyle(
-                    color: gameTheme.leftHudTextColor,
-                    fontSize: 32,
+                  const SizedBox(height: 10),
+                  Text(
+                    (leftPlayerScore >= rightPlayerScore)
+                        ? "You\nWin"
+                        : "You\nLose",
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: gameTheme.leftHudTextColor,
+                      fontSize: 32,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                TileButton(
-                  titleText: "Play Again",
-                  width: 200,
-                  borderColor: gameTheme.backgroundColor,
-                  tileBackgroundColor: gameTheme.ballColor,
-                  onTap: gameReplayPressed,
-                ),
-                const SizedBox(height: 20),
-                TileButton(
-                  titleText: "Quit",
-                  width: 200,
-                  borderColor: gameTheme.backgroundColor,
-                  tileBackgroundColor: gameTheme.ballColor,
-                  onTap: () => Navigator.pop(context),
-                ),
-              ],
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TileButton(
+                    titleText: "Play Again",
+                    width: 200,
+                    borderColor: gameTheme.backgroundColor,
+                    tileBackgroundColor: gameTheme.ballColor,
+                    onTap: gameReplayPressed,
+                  ),
+                  const SizedBox(height: 20),
+                  TileButton(
+                    titleText: "Quit",
+                    width: 200,
+                    borderColor: gameTheme.backgroundColor,
+                    tileBackgroundColor: gameTheme.ballColor,
+                    onTap: () => Navigator.pop(context),
+                  ),
+                ],
+              ),
             ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  "$rightPlayerScore",
-                  style: TextStyle(
-                    color: gameTheme.rightHudTextColor,
-                    fontSize: 32,
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    "$rightPlayerScore",
+                    style: TextStyle(
+                      color: gameTheme.rightHudTextColor,
+                      fontSize: 32,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  isVsComputer
-                      ? (rightPlayerScore > leftPlayerScore
-                          ? "Computer Wins"
-                          : "Computer Loses")
-                      : (rightPlayerScore > leftPlayerScore
-                          ? "You Win"
-                          : "You Lose"),
-                  style: TextStyle(
-                    color: gameTheme.rightHudTextColor,
-                    fontSize: 32,
+                  const SizedBox(height: 10),
+                  Text(
+                    isVsComputer
+                        ? (rightPlayerScore > leftPlayerScore
+                            ? "Computer\nWins"
+                            : "Computer\nLoses")
+                        : (rightPlayerScore > leftPlayerScore
+                            ? "You\nWin"
+                            : "You\nLose"),
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: gameTheme.rightHudTextColor,
+                      fontSize: 32,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/screens/game_app.dart
+++ b/lib/screens/game_app.dart
@@ -13,7 +13,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 enum GameState { welcome, gameOver, playing }
 
 class GameApp extends ConsumerStatefulWidget {
-  const GameApp({super.key});
+  final bool vsComputer;
+  const GameApp({super.key, this.vsComputer = false});
 
   @override
   ConsumerState<GameApp> createState() => _GameAppState();
@@ -30,6 +31,7 @@ class _GameAppState extends ConsumerState<GameApp> {
       isMobile: (!kIsWeb) && (Platform.isAndroid || Platform.isIOS),
       isSfxEnabled: ref.read(settingsProvider).isSfxEnabled,
       gameTheme: ref.read(settingsProvider).getGameTheme(),
+      vsComputer: widget.vsComputer,
     );
   }
 
@@ -80,13 +82,16 @@ class _GameAppState extends ConsumerState<GameApp> {
             game: _game,
             overlayBuilderMap: {
               GameState.welcome.name:
-                  (context, PongGame game) =>
-                      WelcomeOverlay(gameTheme: game.gameTheme),
+                  (context, PongGame game) => WelcomeOverlay(
+                    gameTheme: game.gameTheme,
+                    isVsComputer: game.vsComputer,
+                  ),
               GameState.gameOver.name:
                   (context, PongGame game) => WinnerOverlay(
                     gameTheme: game.gameTheme,
                     leftPlayerScore: game.leftPlayerScore,
                     rightPlayerScore: game.rightPlayerScore,
+                    isVsComputer: game.vsComputer,
                     gameReplayPressed: () {
                       game.overlays.clear();
                       game.gameState = GameState.welcome;

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -38,6 +38,15 @@ class HomeScreen extends StatelessWidget {
                 ),
                 const SizedBox(height: 20),
                 TileButton(
+                  titleText: "Play vs Computer",
+                  width: isPhone() ? 250 : 350,
+                  onTap: () async {
+                    await Navigator.of(context).pushNamed("/vs_computer");
+                    await Flame.device.setPortrait();
+                  },
+                ),
+                const SizedBox(height: 20),
+                TileButton(
                   titleText: "Settings",
                   width: isPhone() ? 250 : 350,
                   onTap: () => Navigator.of(context).pushNamed("/settings"),


### PR DESCRIPTION
## Summary
- add a new "Play vs Computer" option on the home screen
- enable `/vs_computer` route
- extend `GameApp` and `PongGame` with `vsComputer` flag
- update paddles and input handling for AI opponent
- modify overlays to show correct instructions and messages
- document the new mode in the README

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68742a310b1c83249888ac34c84c736d