### PR TITLE
Implement lobby based matchmaking

### DIFF
--- a/lib/screens/online_multiplayer.dart
+++ b/lib/screens/online_multiplayer.dart
@@ -1,59 +1,153 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:easy_pong/notifiers/settings_notifier.dart';
 import 'package:easy_pong/screens/game_app.dart';
+import 'package:easy_pong/services/lobby_service.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class OnlineMultiplayerScreen extends StatefulWidget {
+class OnlineMultiplayerScreen extends ConsumerStatefulWidget {
   const OnlineMultiplayerScreen({super.key});
 
   @override
-  State<OnlineMultiplayerScreen> createState() =>
+  ConsumerState<OnlineMultiplayerScreen> createState() =>
       _OnlineMultiplayerScreenState();
 }
 
-class _OnlineMultiplayerScreenState extends State<OnlineMultiplayerScreen> {
-  final TextEditingController _controller = TextEditingController();
+class _OnlineMultiplayerScreenState
+    extends ConsumerState<OnlineMultiplayerScreen> {
+  late String _userId;
+  LobbyService? _lobby;
+  StreamSubscription<DatabaseEvent>? _requestSub;
 
-  Future<void> _createRoom() async {
-    final roomRef = FirebaseDatabase.instance.ref('rooms').push();
-    await roomRef.set({'createdAt': DateTime.now().toIso8601String()});
-    if (!mounted) return;
-    await Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => GameApp(roomId: roomRef.key)),
-    );
+  @override
+  void initState() {
+    super.initState();
+    _initLobby();
   }
 
-  void _joinRoom() {
-    final id = _controller.text.trim();
-    if (id.isEmpty) return;
-    Navigator.of(
-      context,
-    ).pushReplacement(MaterialPageRoute(builder: (_) => GameApp(roomId: id)));
+  Future<void> _initLobby() async {
+    final prefs = ref.read(sharedPreferencesProvider);
+    _userId =
+        prefs.getString('userId') ??
+        '${DateTime.now().millisecondsSinceEpoch}-${Random().nextInt(1000)}';
+    await prefs.setString('userId', _userId);
+    _lobby = LobbyService(_userId);
+    await _lobby!.init();
+    _requestSub = _lobby!.incomingRequests.listen(_onRequest);
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _onRequest(DatabaseEvent event) async {
+    final fromId = event.snapshot.key;
+    if (fromId == null) return;
+    final accept = await showDialog<bool>(
+      context: context,
+      builder:
+          (context) => AlertDialog(
+            title: const Text('Match Request'),
+            content: Text('$fromId wants to play with you'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Reject'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('Accept'),
+              ),
+            ],
+          ),
+    );
+    if (accept == null) return;
+    final roomId = await _lobby!.respondToRequest(fromId, accept);
+    if (accept && roomId != null && mounted) {
+      await Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => GameApp(roomId: roomId)),
+      );
+    }
+  }
+
+  Future<void> _challenge(String targetId) async {
+    if (_lobby == null) return;
+    await _lobby!.sendRequest(targetId);
+    if (!mounted) return;
+    late StreamSubscription sub;
+    sub = _lobby!.watchRequestTo(targetId).listen((data) async {
+      if (data == null) {
+        await sub.cancel();
+        if (!mounted) return;
+        if (Navigator.canPop(context)) Navigator.pop(context);
+      } else if (data['status'] == 'accepted') {
+        await sub.cancel();
+        final roomId = data['roomId'] as String?;
+        if (roomId != null && mounted) {
+          Navigator.of(context).pop();
+          await Navigator.of(context).pushReplacement(
+            MaterialPageRoute(builder: (_) => GameApp(roomId: roomId)),
+          );
+        }
+      }
+    });
+    await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder:
+          (context) => AlertDialog(
+            title: const Text('Request Sent'),
+            content: const Text('Waiting for response...'),
+            actions: [
+              TextButton(
+                onPressed: () async {
+                  await _lobby!.respondToRequest(targetId, false);
+                  if (!context.mounted) return;
+                  await sub.cancel();
+                  if (!context.mounted) return;
+                  Navigator.pop(context);
+                },
+                child: const Text('Cancel'),
+              ),
+            ],
+          ),
+    );
+    await sub.cancel();
+  }
+
+  @override
+  void dispose() {
+    _requestSub?.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    if (_lobby == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
     return Scaffold(
-      appBar: AppBar(title: const Text('Online Multiplayer')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            TextField(
-              controller: _controller,
-              decoration: const InputDecoration(labelText: 'Room ID'),
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _joinRoom,
-              child: const Text('Join Room'),
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _createRoom,
-              child: const Text('Create Room'),
-            ),
-          ],
-        ),
+      appBar: AppBar(title: Text('Lobby - $_userId')),
+      body: StreamBuilder<List<String>>(
+        stream: _lobby!.onlineUsersStream(),
+        builder: (context, snapshot) {
+          final users = snapshot.data ?? [];
+          if (users.isEmpty) {
+            return const Center(child: Text('No players online'));
+          }
+          return ListView(
+            children: [
+              for (final u in users)
+                ListTile(
+                  title: Text(u),
+                  trailing: ElevatedButton(
+                    onPressed: () => unawaited(_challenge(u)),
+                    child: const Text('Challenge'),
+                  ),
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/services/lobby_service.dart
+++ b/lib/services/lobby_service.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+import 'package:firebase_database/firebase_database.dart';
+
+class LobbyService {
+  LobbyService(this.userId) : _db = FirebaseDatabase.instance;
+
+  final String userId;
+  final FirebaseDatabase _db;
+  DatabaseReference? _presenceRef;
+
+  Future<void> init() async {
+    _presenceRef = _db.ref('lobby/users/$userId');
+    await _presenceRef!.set(true);
+    await _presenceRef!.onDisconnect().remove();
+  }
+
+  Stream<List<String>> onlineUsersStream() {
+    return _db.ref('lobby/users').onValue.map((event) {
+      final value = event.snapshot.value;
+      if (value is Map) {
+        final ids = value.keys.cast<String>().toList();
+        ids.remove(userId);
+        return ids;
+      }
+      return <String>[];
+    });
+  }
+
+  Stream<DatabaseEvent> get incomingRequests =>
+      _db.ref('lobby/requests/$userId').onChildAdded;
+
+  Stream<Map<String, dynamic>?> watchRequestFrom(String fromId) {
+    return _db.ref('lobby/requests/$userId/$fromId').onValue.map((event) {
+      final data = event.snapshot.value;
+      if (data is Map) return Map<String, dynamic>.from(data);
+      return null;
+    });
+  }
+
+  Stream<Map<String, dynamic>?> watchRequestTo(String targetId) {
+    return _db.ref('lobby/requests/$targetId/$userId').onValue.map((event) {
+      final data = event.snapshot.value;
+      if (data is Map) return Map<String, dynamic>.from(data);
+      return null;
+    });
+  }
+
+  Future<void> sendRequest(String targetId) async {
+    await _db.ref('lobby/requests/$targetId/$userId').set({
+      'status': 'pending',
+    });
+  }
+
+  Future<String?> respondToRequest(String fromId, bool accept) async {
+    final ref = _db.ref('lobby/requests/$userId/$fromId');
+    if (!accept) {
+      await ref.remove();
+      return null;
+    }
+    final roomRef = _db.ref('rooms').push();
+    await roomRef.set({'createdAt': DateTime.now().toIso8601String()});
+    final data = {'status': 'accepted', 'roomId': roomRef.key};
+    await ref.set(data);
+    await _db.ref('lobby/requests/$fromId/$userId').set(data);
+    return roomRef.key;
+  }
+}


### PR DESCRIPTION
## Summary
- add `LobbyService` to manage online user presence and match requests
- rework online multiplayer screen into a lobby showing online users
- users can challenge each other and accept or reject matches

## Testing
- `dart format lib/screens/online_multiplayer.dart lib/services/lobby_service.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6874792edb748324b13f3275dc5acb84