### PR TITLE
Enable real-time online multiplayer

### DIFF
--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -2,3 +2,4 @@ export 'ball.dart';
 export 'center_line_divider.dart';
 export 'image_asset_background.dart';
 export 'paddle.dart';
+export 'multiplayer_pong_game.dart';

--- a/lib/components/multiplayer_pong_game.dart
+++ b/lib/components/multiplayer_pong_game.dart
@@ -1,0 +1,65 @@
+import 'package:easy_pong/components/components.dart';
+import 'package:easy_pong/components/pong_game.dart';
+import 'package:easy_pong/services/multiplayer_service.dart';
+import 'package:flame/components.dart';
+
+/// Variant of [PongGame] that synchronizes state over the network using a
+/// [MultiplayerService].
+class MultiplayerPongGame extends PongGame {
+  MultiplayerPongGame({
+    required super.isMobile,
+    required super.isSfxEnabled,
+    required super.gameTheme,
+    required this.service,
+  }) : super(vsComputer: false);
+
+  final MultiplayerService service;
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    service.onData = _handleRemoteData;
+    await service.connect();
+  }
+
+  void _handleRemoteData(Map<String, dynamic> data) {
+    final left = findByKey<Paddle>(ComponentKey.named('LeftPaddle'));
+    final right = findByKey<Paddle>(ComponentKey.named('RightPaddle'));
+    final balls = world.children.query<Ball>();
+    if (data['leftPaddleY'] != null && left != null) {
+      left.position.y = (data['leftPaddleY'] as num).toDouble();
+    }
+    if (data['rightPaddleY'] != null && right != null) {
+      right.position.y = (data['rightPaddleY'] as num).toDouble();
+    }
+    if (balls.isNotEmpty && data['ballX'] != null && data['ballY'] != null) {
+      final ball = balls.first;
+      ball.position.setValues(
+        (data['ballX'] as num).toDouble(),
+        (data['ballY'] as num).toDouble(),
+      );
+    }
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    final left = findByKey<Paddle>(ComponentKey.named('LeftPaddle'));
+    final right = findByKey<Paddle>(ComponentKey.named('RightPaddle'));
+    final balls = world.children.query<Ball>();
+    service.send({
+      'leftPaddleY': left?.position.y,
+      'rightPaddleY': right?.position.y,
+      'ballX': balls.isNotEmpty ? balls.first.position.x : null,
+      'ballY': balls.isNotEmpty ? balls.first.position.y : null,
+      'leftScore': leftPlayerScore,
+      'rightScore': rightPlayerScore,
+    });
+  }
+
+  @override
+  void onRemove() {
+    service.close();
+    super.onRemove();
+  }
+}

--- a/lib/screens/game_app.dart
+++ b/lib/screens/game_app.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:easy_pong/components/multiplayer_pong_game.dart';
 import 'package:easy_pong/components/pong_game.dart';
+import 'package:easy_pong/services/multiplayer_service.dart';
 import 'package:easy_pong/models/computer_difficulty.dart';
 import 'package:easy_pong/notifiers/settings_notifier.dart';
 import 'package:easy_pong/overlays/welcome_overlay.dart';
@@ -36,14 +38,25 @@ class _GameAppState extends ConsumerState<GameApp> {
   void initState() {
     super.initState();
     Flame.device.setLandscape();
-    _game = PongGame(
-      isMobile: (!kIsWeb) && (Platform.isAndroid || Platform.isIOS),
-      isSfxEnabled: ref.read(settingsProvider).isSfxEnabled,
-      gameTheme: ref.read(settingsProvider).getGameTheme(),
-      vsComputer: widget.vsComputer,
-      difficulty: widget.difficulty,
-      roomId: widget.roomId,
-    );
+    final isMobilePlatform = (!kIsWeb) && (Platform.isAndroid || Platform.isIOS);
+    final isOnline = widget.roomId != null && !widget.vsComputer;
+    if (isOnline) {
+      _game = MultiplayerPongGame(
+        isMobile: isMobilePlatform,
+        isSfxEnabled: ref.read(settingsProvider).isSfxEnabled,
+        gameTheme: ref.read(settingsProvider).getGameTheme(),
+        service: MultiplayerService(widget.roomId!),
+      );
+    } else {
+      _game = PongGame(
+        isMobile: isMobilePlatform,
+        isSfxEnabled: ref.read(settingsProvider).isSfxEnabled,
+        gameTheme: ref.read(settingsProvider).getGameTheme(),
+        vsComputer: widget.vsComputer,
+        difficulty: widget.difficulty,
+        roomId: widget.roomId,
+      );
+    }
   }
 
   Future<bool> _onWillPop() async {

--- a/lib/services/multiplayer_service.dart
+++ b/lib/services/multiplayer_service.dart
@@ -1,15 +1,46 @@
+import 'dart:async';
 import 'package:firebase_database/firebase_database.dart';
 
 class MultiplayerService {
   MultiplayerService(this.roomId)
-    : _roomRef = FirebaseDatabase.instance.ref('rooms/$roomId');
+      : _roomRef = FirebaseDatabase.instance.ref('rooms/$roomId'),
+        _stateRef =
+            FirebaseDatabase.instance.ref('rooms/$roomId/state');
 
   final String roomId;
   final DatabaseReference _roomRef;
+  final DatabaseReference _stateRef;
 
+  /// Stream of score updates for backward compatibility.
   Stream<DatabaseEvent> get roomStream => _roomRef.onValue;
 
+  StreamSubscription<DatabaseEvent>? _sub;
+
+  /// Callback invoked whenever new game state is received.
+  void Function(Map<String, dynamic> data)? onData;
+
+  /// Updates the score in the database.
   Future<void> updateState(Map<String, dynamic> data) async {
     await _roomRef.set(data);
+  }
+
+  /// Connects to the realtime state channel and starts listening.
+  Future<void> connect() async {
+    _sub = _stateRef.onValue.listen((event) {
+      final value = event.snapshot.value;
+      if (value is Map) {
+        onData?.call(Map<String, dynamic>.from(value));
+      }
+    });
+  }
+
+  /// Sends the local game state to the remote player.
+  Future<void> send(Map<String, dynamic> data) async {
+    await _stateRef.set(data);
+  }
+
+  /// Stops listening for updates.
+  Future<void> close() async {
+    await _sub?.cancel();
   }
 }


### PR DESCRIPTION
## Summary
- implement `MultiplayerPongGame` for syncing game state over network
- extend `MultiplayerService` with realtime send/receive API
- use `MultiplayerPongGame` in `GameApp` when a room id is provided
- export new component

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68749678bcd0832496b877ee49203d63