### PR TITLE
Improve multiplayer paddle handling

### DIFF
--- a/lib/components/paddle.dart
+++ b/lib/components/paddle.dart
@@ -11,6 +11,7 @@ class Paddle extends PositionComponent
   Paddle({
     required this.paddleBorderRadius,
     required this.paddleColor,
+    this.draggable = true,
     super.key,
     super.position,
     super.size,
@@ -18,6 +19,7 @@ class Paddle extends PositionComponent
 
   final double paddleBorderRadius;
   final Color paddleColor;
+  bool draggable;
 
   double _previousY = 0;
   double _velocityY = 0;
@@ -52,6 +54,7 @@ class Paddle extends PositionComponent
   @override
   void onDragUpdate(DragUpdateEvent event) {
     super.onDragUpdate(event);
+    if (!draggable) return;
     position.y = (position.y + event.localDelta.y).clamp(
       0,
       game.height - size.y,

--- a/lib/screens/game_app.dart
+++ b/lib/screens/game_app.dart
@@ -20,11 +20,13 @@ class GameApp extends ConsumerStatefulWidget {
   final bool vsComputer;
   final ComputerDifficulty difficulty;
   final String? roomId;
+  final bool isLeftPlayer;
   const GameApp({
     super.key,
     this.vsComputer = false,
     this.difficulty = ComputerDifficulty.impossible,
     this.roomId,
+    this.isLeftPlayer = true,
   });
 
   @override
@@ -47,6 +49,7 @@ class _GameAppState extends ConsumerState<GameApp> {
         isSfxEnabled: ref.read(settingsProvider).isSfxEnabled,
         gameTheme: ref.read(settingsProvider).getGameTheme(),
         service: MultiplayerService(widget.roomId!),
+        isLeftPlayer: widget.isLeftPlayer,
       );
     } else {
       _game = PongGame(

--- a/lib/screens/online_multiplayer.dart
+++ b/lib/screens/online_multiplayer.dart
@@ -75,7 +75,9 @@ class _OnlineMultiplayerScreenState
     final roomId = await _lobby!.respondToRequest(fromId, accept);
     if (accept && roomId != null && mounted) {
       await Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => GameApp(roomId: roomId)),
+        MaterialPageRoute(
+          builder: (_) => GameApp(roomId: roomId, isLeftPlayer: false),
+        ),
       );
     }
   }


### PR DESCRIPTION
## Summary
- add control flag to `Paddle` for enabling drag
- restrict controls in `MultiplayerPongGame` and normalize state updates
- pass player side information via `GameApp`
- update online multiplayer screen to set correct side

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6874a4a697348324aea18060812a9101