### PR TITLE
Fix vs computer player orientation

### DIFF
--- a/lib/components/pong_game.dart
+++ b/lib/components/pong_game.dart
@@ -152,13 +152,13 @@ class PongGame extends FlameGame
   @override
   void onDragUpdate(DragUpdateEvent event) {
     super.onDragUpdate(event);
-    if (event.canvasStartPosition.x < width / 2) {
-      //To Move the Left Paddle By Drag
+    if (!vsComputer && event.canvasStartPosition.x < width / 2) {
+      // Move the left paddle only when playing local multiplayer
       findByKey<Paddle>(
         ComponentKey.named('LeftPaddle'),
       )?.moveBy(event.localDelta.y * 2);
-    } else if (!vsComputer) {
-      //To Move the Right Paddle By Drag
+    } else if (event.canvasStartPosition.x >= width / 2) {
+      // Always allow the player to control the right paddle
       findByKey<Paddle>(
         ComponentKey.named('RightPaddle'),
       )?.moveBy(event.localDelta.y * 2);
@@ -171,17 +171,16 @@ class PongGame extends FlameGame
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     super.onKeyEvent(event, keysPressed);
-    //To Move the Right Paddle
-    if (!vsComputer && keysPressed.contains(LogicalKeyboardKey.arrowUp)) {
+    // Move the right paddle (player) using arrow keys
+    if (keysPressed.contains(LogicalKeyboardKey.arrowUp)) {
       findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.moveBy(-paddleStep);
-    } else if (!vsComputer &&
-        keysPressed.contains(LogicalKeyboardKey.arrowDown)) {
+    } else if (keysPressed.contains(LogicalKeyboardKey.arrowDown)) {
       findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.moveBy(paddleStep);
     }
-    //To Move the Left Paddle
-    if (keysPressed.contains(LogicalKeyboardKey.keyW)) {
+    // Move the left paddle only in local multiplayer mode
+    if (!vsComputer && keysPressed.contains(LogicalKeyboardKey.keyW)) {
       findByKey<Paddle>(ComponentKey.named('LeftPaddle'))?.moveBy(-paddleStep);
-    } else if (keysPressed.contains(LogicalKeyboardKey.keyS)) {
+    } else if (!vsComputer && keysPressed.contains(LogicalKeyboardKey.keyS)) {
       findByKey<Paddle>(ComponentKey.named('LeftPaddle'))?.moveBy(paddleStep);
     }
     //To start the game in devices connected to the keyboard
@@ -196,7 +195,8 @@ class PongGame extends FlameGame
   void update(double dt) {
     super.update(dt);
     if (vsComputer && gameState == GameState.playing) {
-      final aiPaddle = findByKey<Paddle>(ComponentKey.named('RightPaddle'));
+      // Computer controls the left paddle in vs computer mode
+      final aiPaddle = findByKey<Paddle>(ComponentKey.named('LeftPaddle'));
       final balls = world.children.query<Ball>();
       if (aiPaddle != null && balls.isNotEmpty) {
         final ball = balls.first;

--- a/lib/overlays/welcome_overlay.dart
+++ b/lib/overlays/welcome_overlay.dart
@@ -33,7 +33,9 @@ class WelcomeOverlay extends StatelessWidget {
           Expanded(
             child: Center(
               child: Text(
-                "W to Move Up\nS to Move Down",
+                isVsComputer
+                    ? 'Computer Opponent'
+                    : 'W to Move Up\nS to Move Down',
                 style: TextStyle(color: gameTheme.leftHudTextColor),
               ),
             ),
@@ -51,9 +53,7 @@ class WelcomeOverlay extends StatelessWidget {
           Expanded(
             child: Center(
               child: Text(
-                isVsComputer
-                    ? 'Computer Opponent'
-                    : 'Up Arrow to Move Up\nDown Arrow to Move Down',
+                'Up Arrow to Move Up\nDown Arrow to Move Down',
                 style: TextStyle(color: gameTheme.leftHudTextColor),
               ),
             ),

--- a/lib/overlays/winner_overlay.dart
+++ b/lib/overlays/winner_overlay.dart
@@ -39,9 +39,13 @@ class WinnerOverlay extends StatelessWidget {
                   ),
                   const SizedBox(height: 10),
                   Text(
-                    (leftPlayerScore >= rightPlayerScore)
-                        ? "You\nWin"
-                        : "You\nLose",
+                    isVsComputer
+                        ? (leftPlayerScore >= rightPlayerScore
+                            ? "Computer\nWins"
+                            : "Computer\nLoses")
+                        : (leftPlayerScore >= rightPlayerScore
+                            ? "You\nWin"
+                            : "You\nLose"),
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       color: gameTheme.leftHudTextColor,
@@ -88,8 +92,8 @@ class WinnerOverlay extends StatelessWidget {
                   Text(
                     isVsComputer
                         ? (rightPlayerScore > leftPlayerScore
-                            ? "Computer\nWins"
-                            : "Computer\nLoses")
+                            ? "You\nWin"
+                            : "You\nLose")
                         : (rightPlayerScore > leftPlayerScore
                             ? "You\nWin"
                             : "You\nLose"),


### PR DESCRIPTION
## Summary
- prevent control of the computer paddle in single player mode
- always control the right paddle when playing vs the computer
- update winner overlay to label the computer on the left
- update welcome overlay instructions for new sides

## Testing
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6874b1cb84b08324b14309d560a15ddf