### PR TITLE
Add room dialogs for online multiplayer

### DIFF
--- a/lib/online/firebase_game_service.dart
+++ b/lib/online/firebase_game_service.dart
@@ -50,4 +50,8 @@ class FirebaseGameService {
   Future<void> dispose() async {
     await _sub?.cancel();
   }
+
+  Future<void> deleteRoom() async {
+    await _roomRef.remove();
+  }
 }

--- a/lib/screens/online_multiplayer.dart
+++ b/lib/screens/online_multiplayer.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'package:easy_pong/functions.dart';
 import 'package:easy_pong/online/firebase_game_service.dart';
@@ -14,9 +15,97 @@ class OnlineMultiplayerScreen extends StatefulWidget {
 }
 
 class _OnlineMultiplayerScreenState extends State<OnlineMultiplayerScreen> {
-  final roomController = TextEditingController();
-
   String get _randomRoom => Random().nextInt(999999).toString().padLeft(6, '0');
+
+  Future<void> _startGame(FirebaseGameService service, bool isHost) async {
+    if (!mounted) return;
+    await Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => OnlineGameApp(service: service, isHost: isHost),
+      ),
+    );
+  }
+
+  Future<void> _createRoom() async {
+    final id = _randomRoom;
+    final service = FirebaseGameService(id, _randomRoom);
+    await service.createRoom();
+    if (!mounted) return;
+    late final StreamSubscription sub;
+    sub = service.roomRef.child('guest').onValue.listen((event) async {
+      if (event.snapshot.value != null) {
+        if (mounted) {
+          Navigator.of(context, rootNavigator: true).pop(true);
+        }
+      }
+    });
+    final result = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) {
+        return AlertDialog(
+          title: const Text('Room ID'),
+          content: SelectableText(id),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                await sub.cancel();
+                await service.deleteRoom();
+                if (mounted) {
+                  Navigator.of(context, rootNavigator: true).pop(false);
+                }
+              },
+              child: const Text('Cancel'),
+            ),
+          ],
+        );
+      },
+    );
+    await sub.cancel();
+    if (result == true) {
+      await _startGame(service, true);
+    }
+  }
+
+  Future<void> _joinRoom() async {
+    final controller = TextEditingController();
+    final id = await showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) {
+        return AlertDialog(
+          title: const Text('Join Room'),
+          content: TextField(
+            controller: controller,
+            maxLength: 6,
+            decoration: const InputDecoration(labelText: 'Room ID'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context, rootNavigator: true).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                if (controller.text.length == 6) {
+                  Navigator.of(
+                    context,
+                    rootNavigator: true,
+                  ).pop(controller.text);
+                }
+              },
+              child: const Text('Join'),
+            ),
+          ],
+        );
+      },
+    );
+    if (id == null) return;
+    final service = FirebaseGameService(id, _randomRoom);
+    await service.joinRoom();
+    if (!mounted) return;
+    await _startGame(service, false);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -34,56 +123,16 @@ class _OnlineMultiplayerScreenState extends State<OnlineMultiplayerScreen> {
                   textAlign: TextAlign.center,
                 ),
                 const Spacer(),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 40),
-                  child: TextField(
-                    controller: roomController,
-                    decoration: const InputDecoration(labelText: 'Room ID'),
-                  ),
-                ),
-                const SizedBox(height: 20),
                 TileButton(
                   titleText: 'Create Room',
                   width: isPhone() ? 250 : 350,
-                  onTap: () async {
-                    final id =
-                        roomController.text.isEmpty
-                            ? _randomRoom
-                            : roomController.text;
-                    final service = FirebaseGameService(id, _randomRoom);
-                    await service.createRoom();
-                    if (context.mounted) {
-                      await Navigator.of(context).pushReplacement(
-                        MaterialPageRoute(
-                          builder:
-                              (_) =>
-                                  OnlineGameApp(service: service, isHost: true),
-                        ),
-                      );
-                    }
-                  },
+                  onTap: _createRoom,
                 ),
                 const SizedBox(height: 20),
                 TileButton(
                   titleText: 'Join Room',
                   width: isPhone() ? 250 : 350,
-                  onTap: () async {
-                    final id = roomController.text;
-                    if (id.isEmpty) return;
-                    final service = FirebaseGameService(id, _randomRoom);
-                    await service.joinRoom();
-                    if (context.mounted) {
-                      await Navigator.of(context).pushReplacement(
-                        MaterialPageRoute(
-                          builder:
-                              (_) => OnlineGameApp(
-                                service: service,
-                                isHost: false,
-                              ),
-                        ),
-                      );
-                    }
-                  },
+                  onTap: _joinRoom,
                 ),
                 const Spacer(flex: 3),
               ],


### PR DESCRIPTION
## Summary
- show an undismissable dialog when creating a room
- allow cancelling the room from dialog
- prompt user for room ID when joining
- clean up rooms via new `deleteRoom` API

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687552c340588324abe1f4c605495f4d