### PR TITLE
Add LAN multiplayer mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:easy_pong/models/computer_difficulty.dart';
 import 'package:easy_pong/notifiers/settings_notifier.dart';
 import 'package:easy_pong/screens/screens.dart';
+import 'package:easy_pong/screens/lan_multiplayer.dart';
 import 'package:flame/flame.dart';
 import 'package:flame_audio/flame_audio.dart';
 import 'package:flutter/foundation.dart';
@@ -56,6 +57,7 @@ class EasyPongApp extends StatelessWidget {
       routes: {
         '/': (context) => const HomeScreen(),
         '/local_multiplayer': (context) => const GameApp(),
+        '/lan_multiplayer': (context) => const LanMultiplayerScreen(),
         '/computer_difficulty': (context) => const ComputerDifficultyScreen(),
         '/vs_computer': (context) {
           final difficulty =

--- a/lib/network/lan_service.dart
+++ b/lib/network/lan_service.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+class LanService {
+  final bool isHost;
+  final int port;
+  ServerSocket? _server;
+  Socket? _socket;
+  final StreamController<String> _controller = StreamController.broadcast();
+
+  LanService.host({this.port = 4567}) : isHost = true;
+  LanService.client({this.port = 4567}) : isHost = false;
+
+  Stream<String> get messages => _controller.stream;
+
+  Future<void> startHost() async {
+    _server = await ServerSocket.bind(InternetAddress.anyIPv4, port);
+    _server!.listen((client) {
+      _socket = client;
+      client.listen(_onData, onDone: _onDone, onError: (_) => _onDone());
+    });
+  }
+
+  Future<void> connect(String host) async {
+    _socket = await Socket.connect(host, port);
+    _socket!.listen(_onData, onDone: _onDone, onError: (_) => _onDone());
+  }
+
+  void send(Map<String, dynamic> data) {
+    final jsonData = jsonEncode(data);
+    _socket?.write('$jsonData\n');
+  }
+
+  void _onData(Uint8List data) {
+    final msg = utf8.decode(data).trim();
+    if (msg.isNotEmpty) {
+      _controller.add(msg);
+    }
+  }
+
+  void _onDone() {
+    _controller.add('disconnect');
+  }
+
+  Future<String> hostAddress() async {
+    final interfaces = await NetworkInterface.list(type: InternetAddressType.IPv4);
+    for (final interface in interfaces) {
+      for (final addr in interface.addresses) {
+        if (!addr.isLoopback) return addr.address;
+      }
+    }
+    return '0.0.0.0';
+  }
+
+  void dispose() {
+    _socket?.destroy();
+    _server?.close();
+  }
+}

--- a/lib/screens/game_app.dart
+++ b/lib/screens/game_app.dart
@@ -7,6 +7,7 @@ import 'package:easy_pong/notifiers/settings_notifier.dart';
 import 'package:easy_pong/overlays/pause_menu_overlay.dart';
 import 'package:easy_pong/overlays/welcome_overlay.dart';
 import 'package:easy_pong/overlays/winner_overlay.dart';
+import 'package:easy_pong/network/lan_service.dart';
 import 'package:flame/flame.dart';
 import 'package:flame/game.dart';
 import 'package:flutter/foundation.dart';
@@ -18,10 +19,14 @@ enum GameState { welcome, gameOver, playing, paused }
 class GameApp extends ConsumerStatefulWidget {
   final bool vsComputer;
   final ComputerDifficulty difficulty;
+  final LanService? lanService;
+  final bool isHost;
   const GameApp({
     super.key,
     this.vsComputer = false,
     this.difficulty = ComputerDifficulty.impossible,
+    this.lanService,
+    this.isHost = false,
   });
 
   @override
@@ -41,6 +46,8 @@ class _GameAppState extends ConsumerState<GameApp> {
       gameTheme: ref.read(settingsProvider).getGameTheme(),
       vsComputer: widget.vsComputer,
       difficulty: widget.difficulty,
+      lanService: widget.lanService,
+      isHost: widget.isHost,
     );
   }
 
@@ -48,6 +55,7 @@ class _GameAppState extends ConsumerState<GameApp> {
   void dispose() {
     _game.pauseEngine();
     _game.overlays.clear();
+    widget.lanService?.dispose();
     super.dispose();
   }
 
@@ -76,6 +84,7 @@ class _GameAppState extends ConsumerState<GameApp> {
         _game.resumeEngine();
         return false;
       }
+      widget.lanService?.send({'type': 'quit'});
       return true;
     }
     return true;
@@ -117,8 +126,9 @@ class _GameAppState extends ConsumerState<GameApp> {
                         game.gameState = GameState.welcome;
                       },
                     ),
-                GameState.paused.name:
-                    (context, PongGame game) => PauseMenuOverlay(game: game),
+                if (widget.lanService == null)
+                  GameState.paused.name:
+                      (context, PongGame game) => PauseMenuOverlay(game: game),
               },
             );
           },

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -38,6 +38,15 @@ class HomeScreen extends StatelessWidget {
                 ),
                 const SizedBox(height: 20),
                 TileButton(
+                  titleText: "LAN Multiplayer",
+                  width: isPhone() ? 250 : 350,
+                  onTap: () async {
+                    await Navigator.of(context).pushNamed('/lan_multiplayer');
+                    await Flame.device.setPortrait();
+                  },
+                ),
+                const SizedBox(height: 20),
+                TileButton(
                   titleText: "Play vs Computer",
                   width: isPhone() ? 250 : 350,
                   onTap: () async {

--- a/lib/screens/lan_multiplayer.dart
+++ b/lib/screens/lan_multiplayer.dart
@@ -1,0 +1,103 @@
+import 'package:easy_pong/network/lan_service.dart';
+import 'package:easy_pong/screens/game_app.dart';
+import 'package:flutter/material.dart';
+
+class LanMultiplayerScreen extends StatefulWidget {
+  const LanMultiplayerScreen({super.key});
+
+  @override
+  State<LanMultiplayerScreen> createState() => _LanMultiplayerScreenState();
+}
+
+class _LanMultiplayerScreenState extends State<LanMultiplayerScreen> {
+  LanService? _service;
+  String? _hostAddress;
+  final TextEditingController _ipController = TextEditingController();
+  bool _hosting = false;
+  String? _status;
+
+  @override
+  void dispose() {
+    _service?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _hostGame() async {
+    _service = LanService.host();
+    await _service!.startHost();
+    _hosting = true;
+    _status = 'Waiting for opponent...';
+    _hostAddress = await _service!.hostAddress();
+    setState(() {});
+    _service!.messages.listen((msg) {
+      if (mounted && msg != 'disconnect') {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (_) => GameApp(
+              lanService: _service,
+              isHost: true,
+            ),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<void> _joinGame() async {
+    final ip = _ipController.text;
+    if (ip.isEmpty) return;
+    _service = LanService.client();
+    await _service!.connect(ip);
+    _service!.send({'type': 'hello'});
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => GameApp(
+          lanService: _service,
+          isHost: false,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('LAN Multiplayer')),
+      body: Center(
+        child: _hosting
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (_hostAddress != null)
+                    Text('Your IP: $_hostAddress'),
+                  const SizedBox(height: 10),
+                  Text(_status ?? ''),
+                ],
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ElevatedButton(
+                    onPressed: _hostGame,
+                    child: const Text('Host Game'),
+                  ),
+                  const SizedBox(height: 20),
+                  TextField(
+                    controller: _ipController,
+                    decoration: const InputDecoration(
+                      labelText: 'Host IP',
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  ElevatedButton(
+                    onPressed: _joinGame,
+                    child: const Text('Join Game'),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -2,3 +2,4 @@ export 'computer_difficulty.dart';
 export 'game_app.dart';
 export 'home.dart';
 export 'settings.dart';
+export 'lan_multiplayer.dart';


### PR DESCRIPTION
## Summary
- add simple LAN networking support
- implement LanMultiplayerScreen UI
- disable pause overlay in LAN mode
- mirror opponent's position via network state
- add navigation option from home screen

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6875ac53a0788324b39c61d0c4a06ad4