### PR TITLE
Add realtime P2P multiplayer mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ If you like what you see, please ⭐ the repo.
 ## ✨ Features
 
 - 🧑‍🤝‍🧑 Ability to play Local Multiplayer (1v1)
+- 🌍 Real Time Multiplayer (Android)
 - 🎮 Play Against The Computer
 - 🕹️ Supported By The Keyboard as well as the Joystick
 - 🎨 Ability To Select From Multiple Different Themes (eq:- classic, football, matrix)
 - 🔉 Built In Sound Effects
 
 ### 🔜 Upcoming Features
- - 🌍 Play Realtime Online Multiplayer Against a Friend
 
 ## 💻 Installation links
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,23 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="tiramisu" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" tools:targetApi="s" />
     <application
         android:label="Easy Pong"
         android:name="${applicationName}"

--- a/lib/components/pong_game.dart
+++ b/lib/components/pong_game.dart
@@ -23,6 +23,7 @@ class PongGame extends FlameGame
     required this.gameTheme,
     this.vsComputer = false,
     this.difficulty = ComputerDifficulty.impossible,
+    this.allowPause = true,
   }) : super(children: [ScreenHitbox()]);
 
   final bool isMobile;
@@ -32,6 +33,7 @@ class PongGame extends FlameGame
   final GameTheme gameTheme;
   final bool vsComputer;
   final ComputerDifficulty difficulty;
+  final bool allowPause;
   int leftPlayerScore = 0;
   int rightPlayerScore = 0;
   late final Vector2 paddleSize;
@@ -120,6 +122,7 @@ class PongGame extends FlameGame
         leftHudTextColor: gameTheme.leftHudTextColor,
         rightHudTextColor: gameTheme.rightHudTextColor,
         fontFamily: gameTheme.hudFontFamily,
+        showPauseButton: allowPause,
       ),
     );
 
@@ -200,7 +203,7 @@ class PongGame extends FlameGame
         event.logicalKey == LogicalKeyboardKey.space) {
       startGame();
     } else if (event.logicalKey == LogicalKeyboardKey.escape) {
-      if (gameState == GameState.playing) {
+      if (allowPause && gameState == GameState.playing) {
         togglePause();
       }
     }
@@ -297,6 +300,7 @@ class PongGame extends FlameGame
   }
 
   void togglePause() {
+    if (!allowPause) return;
     if (_isPaused) {
       resumeEngine();
       gameState = GameState.playing;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ class EasyPongApp extends StatelessWidget {
       routes: {
         '/': (context) => const HomeScreen(),
         '/local_multiplayer': (context) => const GameApp(),
+        '/real_time_multiplayer': (context) => const RealTimeConnectionScreen(),
         '/computer_difficulty': (context) => const ComputerDifficultyScreen(),
         '/vs_computer': (context) {
           final difficulty =

--- a/lib/overlays/score_hud.dart
+++ b/lib/overlays/score_hud.dart
@@ -10,13 +10,15 @@ class ScoreHud extends PositionComponent with HasGameReference<PongGame> {
     required this.leftHudTextColor,
     required this.rightHudTextColor,
     required this.fontFamily,
+    this.showPauseButton = true,
   }) : super();
   final Color leftHudTextColor;
   final Color rightHudTextColor;
   final String fontFamily;
+  final bool showPauseButton;
   late final TextComponent _leftPlayerTextComponent;
   late final TextComponent _rightPlayerTextComponent;
-  late final HudButtonComponent _pauseButton;
+  HudButtonComponent? _pauseButton;
 
   @override
   FutureOr<void> onLoad() {
@@ -45,19 +47,21 @@ class ScoreHud extends PositionComponent with HasGameReference<PongGame> {
         ),
       ),
     );
-    _pauseButton = HudButtonComponent(
-      anchor: Anchor.topCenter,
-      position: Vector2(game.width / 2, 10),
-      size: Vector2.all(40),
-      button: _buildPauseButton(game.gameTheme.ballColor,
-          game.gameTheme.backgroundColor),
-      onPressed: game.togglePause,
-    );
-    addAll([
-      _leftPlayerTextComponent,
-      _rightPlayerTextComponent,
-      _pauseButton,
-    ]);
+    if (showPauseButton) {
+      _pauseButton = HudButtonComponent(
+        anchor: Anchor.topCenter,
+        position: Vector2(game.width / 2, 10),
+        size: Vector2.all(40),
+        button: _buildPauseButton(
+          game.gameTheme.ballColor,
+          game.gameTheme.backgroundColor,
+        ),
+        onPressed: game.togglePause,
+      );
+    }
+    add(_leftPlayerTextComponent);
+    add(_rightPlayerTextComponent);
+    if (_pauseButton != null) add(_pauseButton!);
   }
 
   @override

--- a/lib/p2p/p2p_manager.dart
+++ b/lib/p2p/p2p_manager.dart
@@ -1,0 +1,76 @@
+import 'dart:async';
+import 'package:flutter_p2p_connection/flutter_p2p_connection.dart';
+
+class P2pManager {
+  final bool isHost;
+  FlutterP2pHost? _host;
+  FlutterP2pClient? _client;
+
+  final _controller = StreamController<String>.broadcast();
+  Stream<String> get messages => _controller.stream;
+  void Function()? onOpponentLeft;
+
+  P2pManager.host() : isHost = true;
+  P2pManager.client() : isHost = false;
+
+  Stream<List<P2pClientInfo>>? get clientListStream =>
+      _host?.streamClientList();
+
+  Future<void> initialize() async {
+    if (isHost) {
+      _host = FlutterP2pHost();
+      await _host!.initialize();
+      _host!.streamReceivedTexts().listen(_controller.add);
+      _host!.streamClientList().listen((clients) {
+        if (clients.isEmpty) {
+          onOpponentLeft?.call();
+        }
+      });
+    } else {
+      _client = FlutterP2pClient();
+      await _client!.initialize();
+      _client!.streamReceivedTexts().listen(_controller.add);
+      _client!.streamHotspotState().listen((state) {
+        if (!state.isActive) {
+          onOpponentLeft?.call();
+        }
+      });
+    }
+  }
+
+  Future<void> createGroup() async {
+    if (isHost) {
+      await _host?.createGroup(advertise: true);
+    }
+  }
+
+  Future<void> startScan(
+    Function(List<BleDiscoveredDevice>) result, {
+    Function()? onDone,
+    Function(dynamic)? onError,
+  }) async {
+    if (!isHost) {
+      await _client?.startScan(result, onDone: onDone, onError: onError);
+    }
+  }
+
+  Future<void> connectDevice(BleDiscoveredDevice device) async {
+    if (!isHost) {
+      await _client?.connectWithDevice(device);
+    }
+  }
+
+  Future<void> send(String text) async {
+    if (isHost) {
+      await _host?.broadcastText(text);
+    } else {
+      await _client?.broadcastText(text);
+    }
+  }
+
+  Future<void> dispose() async {
+    await _host?.dispose();
+    await _client?.dispose();
+    await _controller.close();
+  }
+}

--- a/lib/p2p/real_time_pong_game.dart
+++ b/lib/p2p/real_time_pong_game.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:easy_pong/components/components.dart';
+import 'package:easy_pong/components/pong_game.dart';
+import 'package:easy_pong/p2p/p2p_manager.dart';
+import 'package:flame/components.dart';
+import 'package:flame/events.dart';
+
+class RealTimePongGame extends PongGame {
+  final P2pManager manager;
+  final bool isHost;
+
+  RealTimePongGame({
+    required this.manager,
+    required this.isHost,
+    required super.isMobile,
+    required super.isSfxEnabled,
+    required super.gameTheme,
+  }) : super(allowPause: false);
+
+  @override
+  Future<void> onLoad() async {
+    await super.onLoad();
+    manager.messages.listen(_handleMessage);
+  }
+
+  void _handleMessage(String message) {
+    final data = jsonDecode(message) as Map<String, dynamic>;
+    switch (data['type']) {
+      case 'state':
+        if (!isHost) {
+          final ball = world.children.query<Ball>().first;
+          ball.position = Vector2(data['bx'], data['by']);
+          ball.velocity.setFrom(Vector2(data['bvx'], data['bvy']));
+          findByKey<Paddle>(ComponentKey.named('LeftPaddle'))?.position.y =
+              data['ly'];
+          findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.position.y =
+              data['ry'];
+          leftPlayerScore = data['ls'];
+          rightPlayerScore = data['rs'];
+        }
+        break;
+      case 'paddle':
+        if (isHost) {
+          findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.position.y =
+              data['ry'];
+        }
+        break;
+      case 'quit':
+        gameState = GameState.gameOver;
+        if (isHost) {
+          rightPlayerScore = 10;
+        } else {
+          leftPlayerScore = 10;
+        }
+        break;
+    }
+  }
+
+  @override
+  void update(double dt) {
+    super.update(dt);
+    if (isHost && gameState == GameState.playing) {
+      final ball = world.children.query<Ball>().first;
+      manager.send(
+        jsonEncode({
+          'type': 'state',
+          'bx': ball.position.x,
+          'by': ball.position.y,
+          'bvx': ball.velocity.x,
+          'bvy': ball.velocity.y,
+          'ly':
+              findByKey<Paddle>(ComponentKey.named('LeftPaddle'))?.position.y ??
+              0,
+          'ry':
+              findByKey<Paddle>(
+                ComponentKey.named('RightPaddle'),
+              )?.position.y ??
+              0,
+          'ls': leftPlayerScore,
+          'rs': rightPlayerScore,
+        }),
+      );
+    }
+  }
+
+  @override
+  void onDragUpdate(DragUpdateEvent event) {
+    super.onDragUpdate(event);
+    if (!isHost && event.canvasStartPosition.x >= width / 2) {
+      final ry =
+          findByKey<Paddle>(ComponentKey.named('RightPaddle'))?.position.y ?? 0;
+      manager.send(jsonEncode({'type': 'paddle', 'ry': ry}));
+    }
+  }
+
+  @override
+  void onRemove() {
+    manager.send(jsonEncode({'type': 'quit'}));
+    super.onRemove();
+  }
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,6 +2,7 @@ import 'package:easy_pong/functions.dart';
 import 'package:easy_pong/widgets/tile_button.dart';
 import 'package:flame/flame.dart';
 import 'package:flutter/material.dart';
+import 'dart:io';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -36,13 +37,27 @@ class HomeScreen extends StatelessWidget {
                     await Flame.device.setPortrait();
                   },
                 ),
+                if (Platform.isAndroid) ...[
+                  const SizedBox(height: 20),
+                  TileButton(
+                    titleText: "Realtime Multiplayer",
+                    width: isPhone() ? 250 : 350,
+                    onTap: () async {
+                      await Navigator.of(
+                        context,
+                      ).pushNamed('/real_time_multiplayer');
+                      await Flame.device.setPortrait();
+                    },
+                  ),
+                ],
                 const SizedBox(height: 20),
                 TileButton(
                   titleText: "Play vs Computer",
                   width: isPhone() ? 250 : 350,
                   onTap: () async {
-                    await Navigator.of(context)
-                        .pushNamed('/computer_difficulty');
+                    await Navigator.of(
+                      context,
+                    ).pushNamed('/computer_difficulty');
                     await Flame.device.setPortrait();
                   },
                 ),

--- a/lib/screens/real_time_connection.dart
+++ b/lib/screens/real_time_connection.dart
@@ -1,0 +1,111 @@
+import 'package:easy_pong/p2p/p2p_manager.dart';
+import 'package:easy_pong/screens/real_time_game_app.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_p2p_connection/flutter_p2p_connection.dart';
+
+class RealTimeConnectionScreen extends StatefulWidget {
+  const RealTimeConnectionScreen({super.key});
+
+  @override
+  State<RealTimeConnectionScreen> createState() =>
+      _RealTimeConnectionScreenState();
+}
+
+class _RealTimeConnectionScreenState extends State<RealTimeConnectionScreen> {
+  P2pManager? manager;
+  List<BleDiscoveredDevice> devices = [];
+  bool hosting = false;
+  bool joining = false;
+
+  @override
+  void dispose() {
+    manager?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _hostGame() async {
+    manager = P2pManager.host();
+    await manager!.initialize();
+    await manager!.createGroup();
+    setState(() {
+      hosting = true;
+    });
+    manager!.onOpponentLeft = () {
+      if (mounted) Navigator.of(context).pop();
+    };
+    manager!.messages.listen((event) {});
+    manager!.clientListStream?.listen((clients) {
+      if (clients.isNotEmpty) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder:
+                (context) => RealTimeGameApp(manager: manager!, isHost: true),
+          ),
+        );
+      }
+    });
+  }
+
+  Future<void> _joinGame() async {
+    manager = P2pManager.client();
+    await manager!.initialize();
+    setState(() {
+      joining = true;
+    });
+    manager!.startScan((list) {
+      setState(() {
+        devices = list;
+      });
+    });
+  }
+
+  void _connect(BleDiscoveredDevice device) async {
+    await manager!.connectDevice(device);
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (context) => RealTimeGameApp(manager: manager!, isHost: false),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (hosting) {
+      return Scaffold(body: Center(child: Text('Waiting for opponent...')));
+    }
+    if (joining) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Select Host')),
+        body: ListView.builder(
+          itemCount: devices.length,
+          itemBuilder: (context, index) {
+            final d = devices[index];
+            return ListTile(
+              title: Text(d.deviceName ?? 'Unknown'),
+              onTap: () => _connect(d),
+            );
+          },
+        ),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Realtime Multiplayer')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: _hostGame,
+              child: const Text('Host Game'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _joinGame,
+              child: const Text('Join Game'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/real_time_game_app.dart
+++ b/lib/screens/real_time_game_app.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:easy_pong/notifiers/settings_notifier.dart';
+import 'package:easy_pong/p2p/p2p_manager.dart';
+import 'package:easy_pong/p2p/real_time_pong_game.dart';
+import 'package:flame/flame.dart';
+import 'package:flame/game.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RealTimeGameApp extends ConsumerStatefulWidget {
+  final P2pManager manager;
+  final bool isHost;
+  const RealTimeGameApp({
+    super.key,
+    required this.manager,
+    required this.isHost,
+  });
+
+  @override
+  ConsumerState<RealTimeGameApp> createState() => _RealTimeGameAppState();
+}
+
+class _RealTimeGameAppState extends ConsumerState<RealTimeGameApp> {
+  late final RealTimePongGame _game;
+
+  @override
+  void initState() {
+    super.initState();
+    Flame.device.setLandscape();
+    _game = RealTimePongGame(
+      manager: widget.manager,
+      isHost: widget.isHost,
+      isMobile: (!kIsWeb) && (Platform.isAndroid || Platform.isIOS),
+      isSfxEnabled: ref.read(settingsProvider).isSfxEnabled,
+      gameTheme: ref.read(settingsProvider).getGameTheme(),
+    );
+  }
+
+  @override
+  void dispose() {
+    _game.pauseEngine();
+    _game.overlays.clear();
+    widget.manager.dispose();
+    super.dispose();
+  }
+
+  Future<bool> _onWillPop() async {
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        final navigator = Navigator.of(context);
+        if (await _onWillPop()) {
+          if (mounted) navigator.pop(result);
+        }
+      },
+      child: Scaffold(
+        body: GameWidget<RealTimePongGame>(
+          game: _game,
+          overlayBuilderMap: const {},
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -2,3 +2,5 @@ export 'computer_difficulty.dart';
 export 'game_app.dart';
 export 'home.dart';
 export 'settings.dart';
+export 'real_time_connection.dart';
+export 'real_time_game_app.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -174,6 +174,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_p2p_connection:
+    dependency: "direct main"
+    description:
+      name: flutter_p2p_connection
+      sha256: "814a6e35a47a368a9e0812d8375ca3715885abd55049f3371eefd6c25d19e082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -344,6 +352,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: transitive
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_riverpod: ^2.6.1
   shared_preferences: ^2.5.3
   window_manager: ^0.5.1
+  flutter_p2p_connection: ^3.0.2
 
 dev_dependencies:
   flutter_lints: ^6.0.0


### PR DESCRIPTION
## Summary
- add `flutter_p2p_connection` dependency
- implement realtime multiplayer with Wi-Fi Direct
- disable pause HUD when in realtime mode
- update Android manifest for Wi-Fi Direct permissions
- document realtime mode in README

## Testing
- `flutter pub get`
- `dart format lib`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687c209b5b708324b9f2bf6455aa56a4