### PR TITLE
Request runtime permissions for P2P mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you like what you see, please ⭐ the repo.
 ## ✨ Features
 
 - 🧑‍🤝‍🧑 Ability to play Local Multiplayer (1v1)
-- 🌍 Real Time Multiplayer (Android)
+- 🌍 Real Time Multiplayer (Android) with automatic permission requests
 - 🎮 Play Against The Computer
 - 🕹️ Supported By The Keyboard as well as the Joystick
 - 🎨 Ability To Select From Multiple Different Themes (eq:- classic, football, matrix)

--- a/lib/p2p/p2p_manager.dart
+++ b/lib/p2p/p2p_manager.dart
@@ -6,6 +6,27 @@ class P2pManager {
   FlutterP2pHost? _host;
   FlutterP2pClient? _client;
 
+  static final FlutterP2pHost _permissionsHelper = FlutterP2pHost();
+
+  static Future<bool> ensurePermissions() async {
+    var storageGranted = await _permissionsHelper.checkStoragePermission();
+    if (!storageGranted) {
+      storageGranted = await _permissionsHelper.askStoragePermission();
+    }
+
+    var p2pGranted = await _permissionsHelper.checkP2pPermissions();
+    if (!p2pGranted) {
+      p2pGranted = await _permissionsHelper.askP2pPermissions();
+    }
+
+    var bluetoothGranted = await _permissionsHelper.checkBluetoothPermissions();
+    if (!bluetoothGranted) {
+      bluetoothGranted = await _permissionsHelper.askBluetoothPermissions();
+    }
+
+    return storageGranted && p2pGranted && bluetoothGranted;
+  }
+
   final _controller = StreamController<String>.broadcast();
   Stream<String> get messages => _controller.stream;
   void Function()? onOpponentLeft;

--- a/lib/screens/real_time_connection.dart
+++ b/lib/screens/real_time_connection.dart
@@ -19,6 +19,16 @@ class _RealTimeConnectionScreenState extends State<RealTimeConnectionScreen> {
   bool hosting = false;
   bool joining = false;
 
+  Future<bool> _requestPermissions() async {
+    final granted = await P2pManager.ensurePermissions();
+    if (!granted && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Required permissions not granted.')),
+      );
+    }
+    return granted;
+  }
+
   @override
   void dispose() {
     manager?.dispose();
@@ -26,6 +36,7 @@ class _RealTimeConnectionScreenState extends State<RealTimeConnectionScreen> {
   }
 
   Future<void> _hostGame() async {
+    if (!await _requestPermissions()) return;
     manager = P2pManager.host();
     await manager!.initialize();
     await manager!.createGroup();
@@ -49,6 +60,7 @@ class _RealTimeConnectionScreenState extends State<RealTimeConnectionScreen> {
   }
 
   Future<void> _joinGame() async {
+    if (!await _requestPermissions()) return;
     manager = P2pManager.client();
     await manager!.initialize();
     setState(() {


### PR DESCRIPTION
## Summary
- check and request needed permissions for P2P connectivity
- show snackbar if permissions denied
- describe automatic permission requests in README

## Testing
- `dart format lib/p2p/p2p_manager.dart lib/screens/real_time_connection.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687c29eb8dd88324be35a137b9b3ea8a