### PR TITLE
Fix host screen closing immediately

### DIFF
--- a/lib/p2p/p2p_manager.dart
+++ b/lib/p2p/p2p_manager.dart
@@ -25,6 +25,7 @@ class P2pManager {
   final _controller = StreamController<String>.broadcast();
   Stream<String> get messages => _controller.stream;
   void Function()? onOpponentLeft;
+  bool _hadConnectedClient = false;
 
   P2pManager.host() : isHost = true;
   P2pManager.client() : isHost = false;
@@ -38,7 +39,9 @@ class P2pManager {
       await _host!.initialize();
       _host!.streamReceivedTexts().listen(_controller.add);
       _host!.streamClientList().listen((clients) {
-        if (clients.isEmpty) {
+        if (clients.isNotEmpty) {
+          _hadConnectedClient = true;
+        } else if (_hadConnectedClient) {
           onOpponentLeft?.call();
         }
       });


### PR DESCRIPTION
## Summary
- keep track of whether a host ever had a connected client
- only trigger `onOpponentLeft` after at least one connection

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687c31ecd4808324859e9ace8b30e3ab