### PR TITLE
Fix AI paddle speed scaling

### DIFF
--- a/lib/components/pong_game.dart
+++ b/lib/components/pong_game.dart
@@ -231,7 +231,7 @@ class PongGame extends FlameGame
             break;
           case ComputerDifficulty.easy:
             final diff = desiredY - aiPaddle.position.y;
-            final step = diff.clamp(-height * 0.4 * dt, height * 0.4 * dt);
+            final step = diff.clamp(-height * 0.3 * dt, height * 0.3 * dt);
             aiPaddle.position.y = (aiPaddle.position.y + step).clamp(
               0,
               height - aiPaddle.size.y,

--- a/lib/components/pong_game.dart
+++ b/lib/components/pong_game.dart
@@ -222,14 +222,20 @@ class PongGame extends FlameGame
             aiPaddle.position.y = desiredY.clamp(0, height - aiPaddle.size.y);
             break;
           case ComputerDifficulty.medium:
-            aiPaddle.position.y = (aiPaddle.position.y +
-                    (desiredY - aiPaddle.position.y) * 0.1)
-                .clamp(0, height - aiPaddle.size.y);
+            final diff = desiredY - aiPaddle.position.y;
+            final step = diff.clamp(-height * 0.5 * dt, height * 0.5 * dt);
+            aiPaddle.position.y = (aiPaddle.position.y + step).clamp(
+              0,
+              height - aiPaddle.size.y,
+            );
             break;
           case ComputerDifficulty.easy:
-            aiPaddle.position.y = (aiPaddle.position.y +
-                    (desiredY - aiPaddle.position.y) * 0.05)
-                .clamp(0, height - aiPaddle.size.y);
+            final diff = desiredY - aiPaddle.position.y;
+            final step = diff.clamp(-height * 0.4 * dt, height * 0.4 * dt);
+            aiPaddle.position.y = (aiPaddle.position.y + step).clamp(
+              0,
+              height - aiPaddle.size.y,
+            );
             break;
         }
       }


### PR DESCRIPTION
## Summary
- ensure computer opponent moves consistently across screen sizes
- adjust easy and medium difficulty levels so medium is close to easy and easy is more forgiving

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68872d93ae1083249681ffeb711e6afd